### PR TITLE
Revert "Bump html-proofer from 3.18.5 to 3.18.6"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     html-pipeline (2.14.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
-    html-proofer (3.18.6)
+    html-proofer (3.18.5)
       addressable (~> 2.3)
       mercenary (~> 0.3)
       nokogumbo (~> 2.0)


### PR DESCRIPTION
Reverts pheiduck/github-slideshow#34